### PR TITLE
Draft of using `delegate_to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # OSSEC agent and server
 
 Ansible roles for setting up an OSSEC agent and server
+
+## Usage
+Populate hostgroups for the OSSEC server and its clients.
+
+```
+[ossec-manager]
+monitoring.example.com
+
+[ossec-agents]
+web.example.com
+db.example.com
+mail.example.com
+```

--- a/roles/ossec-agent/tasks/main.yml
+++ b/roles/ossec-agent/tasks/main.yml
@@ -13,11 +13,36 @@
     path: /var/ossec/etc/client.keys
   register: ossec_client_keys
 
+- name: check for preexisting agent registration
+  command: /var/ossec/bin/manage_agents -l
+  register: list_agents
+  changed_when: false
+
+- name: make sure authd is not already running on ossec server
+  delegate_to: test-ossec-server
+  command: pkill ossec-authd
+  ignore_errors: true
+  changed_when: false
+
+- name: start authd on ossec server
+  delegate_to: test-ossec-server
+  shell: /var/ossec/bin/ossec-authd -i {{ ossec_agent_ip }} -p 1515 &
+  async: 0
+  poll: 0
+  #when: "'{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available.' not in list_agents.stdout"
+  #  when: "'No agent available' in list_agents.stdout"
+
 - name: run agent auth (if agent is not already added)
-  shell: /var/ossec/bin/agent-auth -m {{ ossec_manager_ip }} -p 1515 -A {{ ossec_agent_hostname }}
+  command: /var/ossec/bin/agent-auth -m {{ ossec_manager_ip }} -p 1515 -A {{ ossec_agent_hostname }}
   when: not ossec_client_keys.stat.exists
 
-- name: restart OSSEC
+- name: restart OSSEC (client)
+  service:
+    name: ossec
+    state: restarted
+
+- name: restart OSSEC (server)
+  delegate_to: test-ossec-server
   service:
     name: ossec
     state: restarted

--- a/roles/ossec-agent/tasks/main.yml
+++ b/roles/ossec-agent/tasks/main.yml
@@ -14,7 +14,7 @@
   register: ossec_client_keys
 
 - name: run agent auth (if agent is not already added)
-  shell: /var/ossec/bin/agent-auth -m {{ manager_ip }} -p 1515 -A {{ agent_hostname }}
+  shell: /var/ossec/bin/agent-auth -m {{ ossec_manager_ip }} -p 1515 -A {{ ossec_agent_hostname }}
   when: not ossec_client_keys.stat.exists
 
 - name: restart OSSEC

--- a/roles/ossec-agent/templates/ossec.conf
+++ b/roles/ossec-agent/templates/ossec.conf
@@ -1,6 +1,6 @@
 <ossec_config>
   <client>
-    <server-ip>{{ manager_ip }}</server-ip>
+    <server-ip>{{ ossec_manager_ip }}</server-ip>
   </client>
 
   <syscheck>

--- a/roles/ossec-manager/tasks/main.yml
+++ b/roles/ossec-manager/tasks/main.yml
@@ -5,17 +5,17 @@
     state: present
 
 - name: check to see if agent already exists
-  shell: /var/ossec/bin/list_agents -a
+  command: /var/ossec/bin/list_agents -a
   register: list_agents
 
 - name: create authd SSL keys
-  shell: openssl genrsa -out /var/ossec/etc/sslmanager.key 4096
+  command: openssl genrsa -out /var/ossec/etc/sslmanager.key 4096
   args:
     creates: /var/ossec/etc/sslmanager.key
   when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
 
 - name: create ssl cert
-  shell: openssl req -new -x509 -batch -subj "/CA=AU/ST=Some-State/locality=city/O=Internet Widgits Pty Ltd/commonName=mon/organizationUnitName=section/emailAddress=admin@localhost" -key /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert -days 365
+  command: openssl req -new -x509 -batch -subj "/CA=AU/ST=Some-State/locality=city/O=Internet Widgits Pty Ltd/commonName=mon/organizationUnitName=section/emailAddress=admin@localhost" -key /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert -days 365
   args:
     creates: /var/ossec/etc/sslmanager.cert
   when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."

--- a/roles/ossec-manager/tasks/main.yml
+++ b/roles/ossec-manager/tasks/main.yml
@@ -12,16 +12,11 @@
   command: openssl genrsa -out /var/ossec/etc/sslmanager.key 4096
   args:
     creates: /var/ossec/etc/sslmanager.key
-  when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
 
 - name: create ssl cert
   command: openssl req -new -x509 -batch -subj "/CA=AU/ST=Some-State/locality=city/O=Internet Widgits Pty Ltd/commonName=mon/organizationUnitName=section/emailAddress=admin@localhost" -key /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert -days 365
   args:
     creates: /var/ossec/etc/sslmanager.cert
-  when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
 
-- name: start authd
-  shell: "/var/ossec/bin/ossec-authd -i {{ ossec_agent_ip }} -p 1515 >/dev/null 2>&1 &"
-  async: 0
-  poll: 0
-  when: list_agents.stdout != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
+
+

--- a/roles/ossec-manager/tasks/main.yml
+++ b/roles/ossec-manager/tasks/main.yml
@@ -12,16 +12,16 @@
   shell: openssl genrsa -out /var/ossec/etc/sslmanager.key 4096
   args:
     creates: /var/ossec/etc/sslmanager.key
-  when: list_agents != "{{ agent_hostname }}-{{ agent_ip }} is available."
+  when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
 
 - name: create ssl cert
   shell: openssl req -new -x509 -batch -subj "/CA=AU/ST=Some-State/locality=city/O=Internet Widgits Pty Ltd/commonName=mon/organizationUnitName=section/emailAddress=admin@localhost" -key /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert -days 365
   args:
     creates: /var/ossec/etc/sslmanager.cert
-  when: list_agents != "{{ agent_hostname }}-{{ agent_ip }} is available."
+  when: list_agents != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."
 
 - name: start authd
-  shell: "/var/ossec/bin/ossec-authd -i {{ agent_ip }} -p 1515 >/dev/null 2>&1 &"
+  shell: "/var/ossec/bin/ossec-authd -i {{ ossec_agent_ip }} -p 1515 >/dev/null 2>&1 &"
   async: 0
   poll: 0
-  when: list_agents.stdout != "{{ agent_hostname }}-{{ agent_ip }} is available."
+  when: list_agents.stdout != "{{ ossec_agent_hostname }}-{{ ossec_agent_ip }} is available."

--- a/vars.yml
+++ b/vars.yml
@@ -1,4 +1,4 @@
 ---
-manager_ip: 45.55.44.234
-agent_ip: 45.55.32.120
-agent_hostname: test-ossec-agent
+ossec_manager_ip: 45.55.44.234
+ossec_agent_ip: 45.55.32.120
+ossec_agent_hostname: test-ossec-agent


### PR DESCRIPTION
Instead of running many partial roles sequentially, we can use the Ansible module `delegate_to` to call the OSSEC server from within the OSSEC agent tasks. Use this as a draft, and merge if it's helpful. Other examples may have cleaner implementations.